### PR TITLE
fix(mssql): use ANSI OFFSET/FETCH syntax for pagination queries

### DIFF
--- a/libs/picodb/lib/PicoDb/Driver/Base.php
+++ b/libs/picodb/lib/PicoDb/Driver/Base.php
@@ -31,7 +31,26 @@ abstract class Base
     protected $pdo = null;
 
     /**
-     * use TOP or LIMIT for returning a subset of rows
+     * use FETCH with OFFSET instead of LIMIT for pagination
+     * default is false, but overridable by the driver
+     *
+     * @access public
+     * @var bool
+     */
+    public bool $useFetch;
+
+    /**
+     * add ROWS suffix to OFFSET clause in SELECT
+     * default is false, but overridable by the driver
+     *
+     * @access public
+     * @var bool
+     */
+    public bool $useOffsetRows;
+
+    /**
+     * use TOP instead of LIMIT for returning a subset of rows
+     * default is false, but overridable by the driver
      *
      * @access public
      * @var bool
@@ -136,6 +155,8 @@ abstract class Base
 
         $this->createConnection($settings);
         $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->useFetch = false;
+        $this->useOffsetRows = false;
         $this->useTop = false;
     }
 

--- a/libs/picodb/lib/PicoDb/Driver/Mssql.php
+++ b/libs/picodb/lib/PicoDb/Driver/Mssql.php
@@ -30,6 +30,8 @@ class Mssql extends Base
     public function __construct(array $settings)
     {
         parent::__construct($settings);
+        $this->useFetch = true;
+        $this->useOffsetRows = true;
         $this->useTop = true;
     }
 

--- a/tests/units/Pagination/TaskPaginationTest.php
+++ b/tests/units/Pagination/TaskPaginationTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Kanboard\Core\Http\Request;
 use Kanboard\Model\ProjectModel;
 use Kanboard\Model\TaskCreationModel;
 use Kanboard\Model\TaskModel;
@@ -26,5 +27,40 @@ class TaskPaginationTest extends Base
         $this->assertCount(1, $taskPagination->getDashboardPaginator(1, 'tasks', 5)->setOrder(TaskModel::TABLE.'.title')->getCollection());
         $this->assertCount(1, $taskPagination->getDashboardPaginator(1, 'tasks', 5)->setOrder(TaskModel::TABLE.'.priority')->getCollection());
         $this->assertCount(1, $taskPagination->getDashboardPaginator(1, 'tasks', 5)->setOrder(TaskModel::TABLE.'.date_due')->getCollection());
+    }
+
+    public function testTaskPaginationTotal() {
+
+        $taskCreationModel = new TaskCreationModel($this->container);
+        $projectModel = new ProjectModel($this->container);
+        $this->assertEquals(1, $projectModel->create(array('name' => 'Project #1')));
+
+        $numTasks = 11;
+        foreach (range(1,$numTasks) as $i) {
+            $this->assertEquals($i, $taskCreationModel->create(array('title' => 'Task #'.$i, 'project_id' => 1)));
+        }
+
+        $taskPaginationTotal = new TaskPagination($this->container);
+        $this->assertEquals($numTasks, $taskPaginationTotal->getDashboardPaginator(0, 'tasks', 5)->getTotal());
+    }
+
+    public function testTaskPaginationPaging() {
+
+        $taskCreationModel = new TaskCreationModel($this->container);
+        $projectModel = new ProjectModel($this->container);
+        $this->assertEquals(1, $projectModel->create(array('name' => 'Project #1')));
+
+        $numTasks = 12;
+        foreach (range(1,$numTasks) as $i) {
+            $this->assertEquals($i, $taskCreationModel->create(array('title' => 'Task #'.$i, 'project_id' => 1)));
+        }
+
+        $taskPaginationMaxM = new TaskPagination($this->container);
+        foreach (range(1,$numTasks) as $m) {
+            foreach(range(1, (int) ceil($numTasks / $m)) as $p) {
+                $this->container['request'] = new Request($this->container, array(), array('page' => $p), array(), array(), array());
+                $this->assertEquals(1+($p-1)*$m , $taskPaginationMaxM->getDashboardPaginator(0, 'tasks', $m)->calculate()->getCollection()[0]['id']);
+            }
+        }
     }
 }


### PR DESCRIPTION
Do you follow the guidelines?

- [X] I have tested my changes
- [ ] There is no breaking change
- [ ] There is no regression
- [ ] I have updated the unit tests and integration tests accordingly
- [ ] I follow the existing [coding style](https://docs.kanboard.org/v1/dev/coding_standards/)

